### PR TITLE
Use system calls instead of NSUserDefaults when to mark intentional quit

### DIFF
--- a/JRFMemoryNoodler.xcodeproj/project.pbxproj
+++ b/JRFMemoryNoodler.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		049635AF1B93E96400FF2F72 /* JRFMemoryNoodler.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 049635A31B93E96400FF2F72 /* JRFMemoryNoodler.framework */; };
 		049635B61B93E96400FF2F72 /* JRFMemoryNoodlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 049635B51B93E96400FF2F72 /* JRFMemoryNoodlerTests.m */; };
 		049635C01B93E97500FF2F72 /* JRFMemoryNoodler.m in Sources */ = {isa = PBXBuildFile; fileRef = 049635BF1B93E97500FF2F72 /* JRFMemoryNoodler.m */; };
+		A275D8E71CB43035005A5AD5 /* JRFPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = A275D8E51CB43035005A5AD5 /* JRFPathUtilities.h */; };
+		A275D8E81CB43035005A5AD5 /* JRFPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = A275D8E61CB43035005A5AD5 /* JRFPathUtilities.m */; };
+		A275D8E91CB43035005A5AD5 /* JRFPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = A275D8E61CB43035005A5AD5 /* JRFPathUtilities.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +34,8 @@
 		049635B41B93E96400FF2F72 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		049635B51B93E96400FF2F72 /* JRFMemoryNoodlerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JRFMemoryNoodlerTests.m; sourceTree = "<group>"; };
 		049635BF1B93E97500FF2F72 /* JRFMemoryNoodler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JRFMemoryNoodler.m; sourceTree = "<group>"; };
+		A275D8E51CB43035005A5AD5 /* JRFPathUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JRFPathUtilities.h; sourceTree = "<group>"; };
+		A275D8E61CB43035005A5AD5 /* JRFPathUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JRFPathUtilities.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +80,8 @@
 			children = (
 				049635A81B93E96400FF2F72 /* JRFMemoryNoodler.h */,
 				049635BF1B93E97500FF2F72 /* JRFMemoryNoodler.m */,
+				A275D8E51CB43035005A5AD5 /* JRFPathUtilities.h */,
+				A275D8E61CB43035005A5AD5 /* JRFPathUtilities.m */,
 				049635A61B93E96400FF2F72 /* Supporting Files */,
 			);
 			path = JRFMemoryNoodler;
@@ -113,6 +120,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				049635A91B93E96400FF2F72 /* JRFMemoryNoodler.h in Headers */,
+				A275D8E71CB43035005A5AD5 /* JRFPathUtilities.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,6 +220,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A275D8E81CB43035005A5AD5 /* JRFPathUtilities.m in Sources */,
 				049635C01B93E97500FF2F72 /* JRFMemoryNoodler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -220,6 +229,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A275D8E91CB43035005A5AD5 /* JRFPathUtilities.m in Sources */,
 				049635B61B93E96400FF2F72 /* JRFMemoryNoodlerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JRFMemoryNoodler/JRFMemoryNoodler.m
+++ b/JRFMemoryNoodler/JRFMemoryNoodler.m
@@ -9,6 +9,7 @@
 @import UIKit;
 
 #import "JRFMemoryNoodler.h"
+#import "JRFPathUtilities.h"
 
 #include <sys/stat.h>
 
@@ -28,12 +29,11 @@ static char *intentionalQuitPathname;
     signal(SIGABRT, JRFIntentionalQuitHandler);
     signal(SIGQUIT, JRFIntentionalQuitHandler);
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
 
     // Set up the static path for intentional aborts
-    NSString *appSupportDirectory = [paths objectAtIndex:0];
-    NSString *fileName = [NSString stringWithFormat:@"%@/intentionalquit.txt", appSupportDirectory];
-    intentionalQuitPathname = strdup([fileName UTF8String]);
+    if ([JRFPathUtilities intentionalQuitPathname]) {
+        intentionalQuitPathname = strdup([JRFPathUtilities intentionalQuitPathname]);
+    }
 
     JRFCrashDetector detector = crashDetector;
     if (!detector) {
@@ -147,8 +147,7 @@ static void defaultExceptionHandler (NSException *exception) {
 }
 
 static void JRFIntentionalQuitHandler(int signal) {
-    int fd;
-    fd = creat(intentionalQuitPathname, S_IREAD | S_IWRITE);
+    creat(intentionalQuitPathname, S_IREAD | S_IWRITE);
 }
 
 + (JRFCrashDetector)defaultCrashDetector {

--- a/JRFMemoryNoodler/JRFPathUtilities.h
+++ b/JRFMemoryNoodler/JRFPathUtilities.h
@@ -1,0 +1,15 @@
+//
+//  JRFPathUtilities.h
+//  JRFMemoryNoodler
+//
+//  Created by Wendy Lu on 4/5/16.
+//  Copyright © 2016 jflinter. All rights reserved.
+//
+
+@import Foundation;
+
+@interface JRFPathUtilities : NSObject
+
++ (const char *)intentionalQuitPathname;
+
+@end

--- a/JRFMemoryNoodler/JRFPathUtilities.m
+++ b/JRFMemoryNoodler/JRFPathUtilities.m
@@ -1,0 +1,26 @@
+//
+//  JRFPathUtilities.m
+//  JRFMemoryNoodler
+//
+//  Created by Wendy Lu on 4/5/16.
+//  Copyright © 2016 jflinter. All rights reserved.
+//
+
+#import "JRFPathUtilities.h"
+
+@implementation JRFPathUtilities
+
+
++ (const char *)intentionalQuitPathname
+{
+    NSString *appSupportDirectory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) lastObject];
+    if (![[NSFileManager defaultManager] fileExistsAtPath:appSupportDirectory isDirectory:NULL]) {
+        if (![[NSFileManager defaultManager] createDirectoryAtPath:appSupportDirectory withIntermediateDirectories:YES attributes:nil error:nil]) {
+            return 0;
+        }
+    }
+    NSString *fileName = [appSupportDirectory stringByAppendingPathComponent:@"intentionalquit"];
+    return [fileName UTF8String];
+}
+
+@end

--- a/JRFMemoryNoodlerTests/JRFMemoryNoodlerTests.m
+++ b/JRFMemoryNoodlerTests/JRFMemoryNoodlerTests.m
@@ -10,6 +10,7 @@
 @import XCTest;
 @import JRFMemoryNoodler;
 
+#import "JRFPathUtilities.h"
 @interface JRFMemoryNoodlerTests : XCTestCase
 @end
 
@@ -24,7 +25,7 @@
 }
 
 - (void)testAbortDoesNotTriggerOutOfMemoryWarning {
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"JRFAppDidAbortKey"];
+    creat([JRFPathUtilities intentionalQuitPathname], S_IREAD | S_IWRITE);
     [self checkMemoryNoodlerWithExpectation:NO shouldBeInForeground:YES didCrash:NO];
 }
 
@@ -46,6 +47,14 @@
 - (void)testBackgroundingTracksProperly {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"JRFAppWasInBackgroundKey"];
     [self checkMemoryNoodlerWithExpectation:NO shouldBeInForeground:NO didCrash:YES];
+}
+
+- (void)testIntentionalQuitPathNameIsStable {
+    const char *pathname1 = [JRFPathUtilities intentionalQuitPathname];
+    const char *pathname2 = [JRFPathUtilities intentionalQuitPathname];
+    if (strcmp(pathname1, pathname2)) {
+        XCTFail(@"Intentional Quit pathnames not equal");
+    }
 }
 
 - (void)checkMemoryNoodlerWithExpectation:(BOOL)shouldRegisterOutOfMemory


### PR DESCRIPTION
There is a rare crash in the abort handler that we believe is from calling malloc
when the system is already in a memory crash. Using system calls instead of 
Obj C functions here may help avoid allocating additional memory when we are in the middle of a crash stack.

<img width="685" alt="screen shot 2016-03-28 at 5 20 41 pm" src="https://cloud.githubusercontent.com/assets/5505885/14094275/6e8f2b8c-f509-11e5-9978-c6d9e03e2dc9.png">
